### PR TITLE
Miscellaneous enhancement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .vscode/
 *.bag
 fast_lio_sam_qn/*.bag
+/fast_lio_sam_qn/result.pcd
+/fast_lio_sam_qn/sequence*/

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@
     sudo apt install libtbb-dev
     ```
 
-## How to build and use
+## How to build 
 + Get the code and then build the main code.
     ```shell
     cd ~/your_workspace/src
@@ -76,12 +76,24 @@
     catkin build -DCMAKE_BUILD_TYPE=Release
     . devel/setup.bash
     ```
+
+## How to run
+
 + Then run (change config files in third_party/`FAST_LIO`)
-    ```shell
-    roslaunch fast_lio_sam_qn run.launch lidar:=ouster
-    roslaunch fast_lio_sam_qn run.launch lidar:=velodyne
-    roslaunch fast_lio_sam_qn run.launch lidar:=livox
-    ```
+ 
+```shell
+roslaunch fast_lio_sam_qn run.launch lidar:=ouster
+roslaunch fast_lio_sam_qn run.launch lidar:=velodyne
+roslaunch fast_lio_sam_qn run.launch lidar:=livox
+```
+
+* In particular, we provide a preset launch option for specific datasets:
+ 
+```shell
+roslaunch fast_lio_sam_qn run.launch lidar:=kitti
+roslaunch fast_lio_sam_qn run.launch lidar:=mulran
+roslaunch fast_lio_sam_qn run.launch lidar:=newer-college20
+```
 
 <br>
 

--- a/fast_lio_sam_qn/config/config.yaml
+++ b/fast_lio_sam_qn/config/config.yaml
@@ -29,8 +29,8 @@ quatro:                                       # all values are from Quatro offic
   optimize_matching: true                     # whether or not to use Optimized matching
   distance_threshold: 35.0                    # when optimized matching, use only correspondences within this radius, unit [meter]
   max_correspondences: 500                    # max correspondences to use for optimized matching 
-  fpfh_normal_radius: 0.6                     # should satisfy the following condition: fpfh_radius >= 1.5 * fpfh_normal_radius
-  fpfh_radius: 0.9                            # should satisfy the following condition: fpfh_radius >= 1.5 * fpfh_normal_radius
+  fpfh_normal_radius: 0.9                     # should satisfy the following condition: fpfh_radius >= 1.5 * fpfh_normal_radius
+  fpfh_radius: 1.5                            # should satisfy the following condition: fpfh_radius >= 1.5 * fpfh_normal_radius
   estimating_scale: false 
   noise_bound: 0.3                            # The magnitude of uncertainty of measurements, the best is within v/2 ~ v (v: voxel resol.)
   rotation:

--- a/fast_lio_sam_qn/config/config.yaml
+++ b/fast_lio_sam_qn/config/config.yaml
@@ -6,6 +6,7 @@ basic:
 keyframe:
   keyframe_threshold: 1.5                     # unit [meter] every this distance, generate keyframe
   subkeyframes_number: 5                      # how many subkeyframes are merged to ICP with current keyframe (closest-this ~ closest+this, if exists)
+  enable_submap_matching: true                # If it is set to be `true`, submap-level (coarse-to-)fine alignment will be performed
 
 loop:
   loop_detection_radius: 35.0                 # unit [meter] within this radius, check if loop or not

--- a/fast_lio_sam_qn/config/config.yaml
+++ b/fast_lio_sam_qn/config/config.yaml
@@ -40,5 +40,7 @@ quatro:                                       # all values are from Quatro offic
                                               # Once the diff. of cost < `rot_cost_diff_threshold`, then the optimization is finished.
 
 result:
-  save_map_pcd: false                         # Save result map in .pcd format, not voxelized and hence file size could be huge
-  save_map_bag: true                          # Save result map in .bag format, NOTE: this is used for FAST-LIO-Localization-QN (https://github.com/engcang/FAST-LIO-Localization-QN)
+  save_map_pcd: true                         # Save result map in .pcd format, not voxelized and hence file size could be huge
+  save_map_bag: false                        # Save result map in .bag format, NOTE: this is used for FAST-LIO-Localization-QN (https://github.com/engcang/FAST-LIO-Localization-QN)
+  save_in_kitti_format: true                 # Save result in KITTI format
+  seq_name: "sequence"                       # sequence name for saving scans and corresponding poses

--- a/fast_lio_sam_qn/include/main.h
+++ b/fast_lio_sam_qn/include/main.h
@@ -23,6 +23,7 @@
 #include <tf/transform_datatypes.h> // createQuaternionFromRPY
 #include <tf_conversions/tf_eigen.h> // tf <-> eigen
 #include <tf/transform_broadcaster.h> // broadcaster
+#include <std_msgs/String.h>
 #include <sensor_msgs/PointCloud2.h>
 #include <geometry_msgs/PoseStamped.h>
 #include <nav_msgs/Odometry.h>
@@ -121,10 +122,11 @@ class FastLioSamQnClass
     ros::Publisher m_realtime_pose_pub;
     ros::Publisher m_debug_src_pub, m_debug_dst_pub, m_debug_coarse_aligned_pub, m_debug_fine_aligned_pub;
     ros::Timer m_loop_timer, m_vis_timer;
-    // odom, pcd sync subscriber
+    // odom, pcd sync, and save flag subscribers
     shared_ptr<message_filters::Synchronizer<odom_pcd_sync_pol>> m_sub_odom_pcd_sync = nullptr;
     shared_ptr<message_filters::Subscriber<nav_msgs::Odometry>> m_sub_odom = nullptr;
     shared_ptr<message_filters::Subscriber<sensor_msgs::PointCloud2>> m_sub_pcd = nullptr;
+    ros::Subscriber m_sub_save_flag;
 
     ///// functions
   public:
@@ -147,6 +149,7 @@ class FastLioSamQnClass
     visualization_msgs::Marker getLoopMarkers(const gtsam::Values &corrected_esti_in);
     //cb
     void odomPcdCallback(const nav_msgs::OdometryConstPtr &odom_msg, const sensor_msgs::PointCloud2ConstPtr &pcd_msg);
+    void SaveFlagCallback(const std_msgs::String::ConstPtr &msg);
     void loopTimerFunc(const ros::TimerEvent& event);
     void visTimerFunc(const ros::TimerEvent& event);
 };

--- a/fast_lio_sam_qn/include/main.h
+++ b/fast_lio_sam_qn/include/main.h
@@ -13,6 +13,7 @@
 #include <mutex>
 #include <string>
 #include <utility> // pair, make_pair
+#include <filesystem>
 ///// ROS
 #include <ros/ros.h>
 #include <ros/package.h> // get package_path
@@ -80,6 +81,7 @@ class FastLioSamQnClass
     ///// basic params
     std::string m_map_frame;
     std::string m_package_path;
+    std::string m_seq_name;
     ///// shared data - odom and pcd
     std::mutex m_realtime_pose_mutex, m_keyframes_mutex;
     std::mutex m_graph_mutex, m_vis_mutex;
@@ -111,7 +113,7 @@ class FastLioSamQnClass
     nav_msgs::Path m_odom_path, m_corrected_path;
     bool m_global_map_vis_switch = true;
     ///// results
-    bool m_save_map_bag = false, m_save_map_pcd = false;
+    bool m_save_map_bag = false, m_save_map_pcd = false, m_save_in_kitti_format = false;
     ///// ros
     ros::NodeHandle m_nh;
     ros::Publisher m_corrected_odom_pub, m_corrected_path_pub, m_odom_pub, m_path_pub;

--- a/fast_lio_sam_qn/include/main.h
+++ b/fast_lio_sam_qn/include/main.h
@@ -75,6 +75,13 @@ struct PosePcd
   PosePcd(){};
   PosePcd(const nav_msgs::Odometry &odom_in, const sensor_msgs::PointCloud2 &pcd_in, const int &idx_in);
 };
+
+struct RegistrationOutput
+{
+  Eigen::Matrix4d pose_between_eig = Eigen::Matrix4d::Identity();
+  bool is_converged                = false;
+  double score                     = std::numeric_limits<float>::max();
+};
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 class FastLioSamQnClass
 {
@@ -131,6 +138,8 @@ class FastLioSamQnClass
 
     ///// functions
   public:
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
     FastLioSamQnClass(const ros::NodeHandle& n_private);
     ~FastLioSamQnClass();
   private:
@@ -140,10 +149,8 @@ class FastLioSamQnClass
     bool checkIfKeyframe(const PosePcd &pose_pcd_in, const PosePcd &latest_pose_pcd);
     int getClosestKeyframeIdx(const PosePcd &front_keyframe, const std::vector<PosePcd> &keyframes);
     std::tuple<pcl::PointCloud<PointType>, pcl::PointCloud<PointType>> setSrcAndDstCloud(std::vector<PosePcd> keyframes, const int src_idx, const int dst_idx, const int submap_range, const bool enable_quatro, const bool enable_submap_matching);
-    Eigen::Matrix4d icpAlignment(const pcl::PointCloud<PointType> &src_raw_, const pcl::PointCloud<PointType> &dst_raw_, 
-                                 bool &if_converged, double &score);
-    Eigen::Matrix4d coarseToFineAlignment(const pcl::PointCloud<PointType> &src_raw_, const pcl::PointCloud<PointType> &dst_raw_,
-                                         bool &if_converged, double &score);
+    RegistrationOutput icpAlignment(const pcl::PointCloud<PointType> &src_raw_, const pcl::PointCloud<PointType> &dst_raw_);
+    RegistrationOutput coarseToFineAlignment(const pcl::PointCloud<PointType> &src_raw_, const pcl::PointCloud<PointType> &dst_raw_);
     visualization_msgs::Marker getLoopMarkers(const gtsam::Values &corrected_esti_in);
     //cb
     void odomPcdCallback(const nav_msgs::OdometryConstPtr &odom_msg, const sensor_msgs::PointCloud2ConstPtr &pcd_msg);

--- a/fast_lio_sam_qn/include/main.h
+++ b/fast_lio_sam_qn/include/main.h
@@ -102,6 +102,7 @@ class FastLioSamQnClass
     pcl::VoxelGrid<PointType> m_voxelgrid, m_voxelgrid_vis;
     nano_gicp::NanoGICP<PointType, PointType> m_nano_gicp;
     shared_ptr<quatro<PointType>> m_quatro_handler = nullptr;
+    bool m_enable_submap_matching = false;
     bool m_enable_quatro = false;
     double m_icp_score_thr, m_loop_det_radi, m_loop_det_tdiff_thr;
     int m_sub_key_num;
@@ -138,14 +139,11 @@ class FastLioSamQnClass
     void voxelizePcd(pcl::VoxelGrid<PointType> &voxelgrid, pcl::PointCloud<PointType> &pcd_in);
     bool checkIfKeyframe(const PosePcd &pose_pcd_in, const PosePcd &latest_pose_pcd);
     int getClosestKeyframeIdx(const PosePcd &front_keyframe, const std::vector<PosePcd> &keyframes);
-    Eigen::Matrix4d icpKeyToSubkeys(const PosePcd &front_keyframe, const int &closest_idx, 
-                                    const std::vector<PosePcd> &keyframes, bool &if_converged, double &score);
-    Eigen::Matrix4d coarseToFineKeyToKey(const PosePcd &front_keyframe, const int &closest_idx,
-                                         const std::vector<PosePcd> &keyframes, bool &if_converged, double &score);
-    Eigen::Matrix4d icpSubkeysToSubkeys(const std::deque<PosePcd> &front_keyframes, const int& not_processed_idx,
-                                        const int &closest_idx, const std::vector<PosePcd> &keyframes, bool &if_converged, double &score);
-    Eigen::Matrix4d coarseToFineSubkeysToSubkeys(const std::deque<PosePcd> &front_keyframes, const int& not_processed_idx,
-                                                 const int &closest_idx, const std::vector<PosePcd> &keyframes, bool &if_converged, double &score);
+    std::tuple<pcl::PointCloud<PointType>, pcl::PointCloud<PointType>> setSrcAndDstCloud(std::vector<PosePcd> keyframes, const int src_idx, const int dst_idx, const int submap_range, const bool enable_quatro, const bool enable_submap_matching);
+    Eigen::Matrix4d icpAlignment(const pcl::PointCloud<PointType> &src_raw_, const pcl::PointCloud<PointType> &dst_raw_, 
+                                 bool &if_converged, double &score);
+    Eigen::Matrix4d coarseToFineAlignment(const pcl::PointCloud<PointType> &src_raw_, const pcl::PointCloud<PointType> &dst_raw_,
+                                         bool &if_converged, double &score);
     visualization_msgs::Marker getLoopMarkers(const gtsam::Values &corrected_esti_in);
     //cb
     void odomPcdCallback(const nav_msgs::OdometryConstPtr &odom_msg, const sensor_msgs::PointCloud2ConstPtr &pcd_msg);

--- a/fast_lio_sam_qn/launch/run.launch
+++ b/fast_lio_sam_qn/launch/run.launch
@@ -33,5 +33,8 @@
 	<include if="$(eval arg ('lidar') == 'newer-college2020')" file="$(find fast_lio)/../fastlio_config_launch/newer-college2020.launch">
 		<arg name="rviz" value="false"/>
 	</include>
+	<include if="$(eval arg ('lidar') == 'kimera-multi')" file="$(find fast_lio)/../fastlio_config_launch/kimera-multi.launch">
+		<arg name="rviz" value="false"/>
+	</include>
 
 </launch>

--- a/fast_lio_sam_qn/launch/run.launch
+++ b/fast_lio_sam_qn/launch/run.launch
@@ -24,10 +24,13 @@
 	<include if="$(eval arg ('lidar') == 'hilti')" file="$(find fast_lio)/launch/hilti.launch">
 		<arg name="rviz" value="false"/>
 	</include>
-	<include if="$(eval arg ('lidar') == 'kitti')" file="$(find fast_lio)/launch/kitti.launch">
+	<include if="$(eval arg ('lidar') == 'kitti')" file="$(find fast_lio)/../fastlio_config_launch/kitti.launch">
 		<arg name="rviz" value="false"/>
 	</include>
-	<include if="$(eval arg ('lidar') == 'mulran')" file="$(find fast_lio)/launch/mulran.launch">
+	<include if="$(eval arg ('lidar') == 'mulran')" file="$(find fast_lio)/../fastlio_config_launch/mulran.launch">
+		<arg name="rviz" value="false"/>
+	</include>
+	<include if="$(eval arg ('lidar') == 'newer-college2020')" file="$(find fast_lio)/../fastlio_config_launch/newer-college2020.launch">
 		<arg name="rviz" value="false"/>
 	</include>
 

--- a/fast_lio_sam_qn/launch/run.launch
+++ b/fast_lio_sam_qn/launch/run.launch
@@ -2,6 +2,8 @@
 
 	<arg name="rviz" default="true" />
 	<arg name="lidar" default="ouster" /> <!-- ouster, velodyne, livox -->
+	<arg name="odom_topic" default="/Odometry" /> 
+	<arg name="lidar_topic" default="/cloud_registered" /> 
 
 	<!-- visualize -->
 	<!-- <node if="$(arg rviz)" pkg="rviz" type="rviz" name="rviz_lio" args="-d $(find fast_lio_sam_qn)/config/lio_rviz.rviz" launch-prefix="nice"/> -->
@@ -9,7 +11,10 @@
 	
 	<!-- run fast_lio_sam_qn -->
 	<rosparam command="load" file="$(find fast_lio_sam_qn)/config/config.yaml" />
-	<node pkg="fast_lio_sam_qn" type="fast_lio_sam_qn_node" name="fast_lio_sam_qn_node" output="screen"/> 
+	<node pkg="fast_lio_sam_qn" type="fast_lio_sam_qn_node" name="fast_lio_sam_qn_node" output="screen">
+    <remap from="/Odometry" to="$(arg odom_topic)"/>
+    <remap from="/cloud_registered" to="$(arg lidar_topic)"/>
+  </node>
 
 	<!-- run fast_lio -->
 	<include if="$(eval arg ('lidar') == 'ouster')" file="$(find fast_lio)/launch/mapping_ouster64.launch">
@@ -33,7 +38,13 @@
 	<include if="$(eval arg ('lidar') == 'newer-college2020')" file="$(find fast_lio)/../fastlio_config_launch/newer-college2020.launch">
 		<arg name="rviz" value="false"/>
 	</include>
-	<include if="$(eval arg ('lidar') == 'kimera-multi')" file="$(find fast_lio)/../fastlio_config_launch/kimera-multi.launch">
+	<include if="$(eval arg ('lidar') == 'kimera-multi-acl_jackal2')" file="$(find fast_lio)/../fastlio_config_launch/kimera-multi-acl_jackal2.launch">
+		<arg name="rviz" value="false"/>
+	</include>
+  <include if="$(eval arg ('lidar') == 'kimera-multi-apis')" file="$(find fast_lio)/../fastlio_config_launch/kimera-multi-apis.launch">
+		<arg name="rviz" value="false"/>
+	</include>
+	<include if="$(eval arg ('lidar') == 'vbr-colosseo')" file="$(find fast_lio)/../fastlio_config_launch/vbr-colosseo.launch">
 		<arg name="rviz" value="false"/>
 	</include>
 

--- a/fast_lio_sam_qn/src/constructor.cpp
+++ b/fast_lio_sam_qn/src/constructor.cpp
@@ -1,5 +1,6 @@
 #include "main.h"
 
+namespace fs = std::filesystem;
 
 PosePcd::PosePcd(const nav_msgs::Odometry &odom_in, const sensor_msgs::PointCloud2 &pcd_in, const int &idx_in)
 {
@@ -67,6 +68,8 @@ FastLioSamQnClass::FastLioSamQnClass(const ros::NodeHandle& n_private) : m_nh(n_
   /* results */
   m_nh.param<bool>("/result/save_map_bag", m_save_map_bag, false);
   m_nh.param<bool>("/result/save_map_pcd", m_save_map_pcd, false);
+  m_nh.param<bool>("/result/save_in_kitti_format", m_save_in_kitti_format, false);
+  m_nh.param<std::string>("/result/seq_name", m_seq_name, "");
 
   ////// GTSAM init
   gtsam::ISAM2Params isam_params_;
@@ -149,5 +152,41 @@ FastLioSamQnClass::~FastLioSamQnClass()
     }
     pcl::io::savePCDFileASCII<PointType> (m_package_path+"/result.pcd", corrected_map_);
     cout << "\033[32;1mResult saved in .pcd format!!!\033[0m" << endl;
+  }
+  // save scans as individual pcd files and poses in KITTI format
+  if (m_save_in_kitti_format)
+  {
+    // Delete the scans folder if it exists and create a new one
+    std::string seq_directory = m_package_path + "/" + m_seq_name;
+    std::string scans_directory = seq_directory + "/scans";
+    std::cout << "Debug " << std::endl;
+    if (fs::exists(seq_directory))
+    {
+      fs::remove_all(seq_directory);
+    }
+    fs::create_directories(scans_directory);
+
+    std::ofstream pose_file(seq_directory + "/poses.txt");
+    std::cout << "Debug2 " << std::endl;
+    {
+      std::lock_guard<std::mutex> lock(m_keyframes_mutex);
+      for (int i = 0; i < m_keyframes.size(); ++i)
+      {
+        std::cout << "Debug3 -> " << i << std::endl;
+        // Save the point cloud
+        std::stringstream ss;
+        ss << scans_directory << "/" << std::setw(6) << std::setfill('0') << i << ".pcd";
+        std::cout << ss.str() << std::endl;
+        pcl::io::savePCDFileASCII<PointType>(ss.str(), m_keyframes[i].pcd);
+
+        // Save the pose in KITTI format
+        const auto& pose = m_keyframes[i].pose_corrected_eig;
+        pose_file << pose(0, 0) << " " << pose(0, 1) << " " << pose(0, 2) << " " << pose(0, 3) << " "
+                  << pose(1, 0) << " " << pose(1, 1) << " " << pose(1, 2) << " " << pose(1, 3) << " "
+                  << pose(2, 0) << " " << pose(2, 1) << " " << pose(2, 2) << " " << pose(2, 3) << "\n";
+      }
+    }
+    pose_file.close();
+    cout << "\033[33;1mScans and poses saved in .pcd and KITTI format!!!\033[0m" << endl;
   }
 }

--- a/fast_lio_sam_qn/src/constructor.cpp
+++ b/fast_lio_sam_qn/src/constructor.cpp
@@ -40,6 +40,7 @@ FastLioSamQnClass::FastLioSamQnClass(const ros::NodeHandle& n_private) : m_nh(n_
   /* keyframe */
   m_nh.param<double>("/keyframe/keyframe_threshold", m_keyframe_thr, 1.0);
   m_nh.param<int>("/keyframe/subkeyframes_number", m_sub_key_num, 5);
+  m_nh.param<bool>("/keyframe/enable_submap_matching", m_enable_submap_matching, false);
   /* loop */
   m_nh.param<double>("/loop/loop_detection_radius", m_loop_det_radi, 15.0);
   m_nh.param<double>("/loop/loop_detection_timediff_threshold", m_loop_det_tdiff_thr, 10.0);

--- a/fast_lio_sam_qn/src/methods.cpp
+++ b/fast_lio_sam_qn/src/methods.cpp
@@ -66,7 +66,7 @@ int FastLioSamQnClass::getClosestKeyframeIdx(const PosePcd &front_keyframe, cons
 std::tuple<pcl::PointCloud<PointType>, pcl::PointCloud<PointType>> FastLioSamQnClass::setSrcAndDstCloud(std::vector<PosePcd> keyframes, const int src_idx, const int dst_idx, const int submap_range, const bool enable_quatro, const bool enable_submap_matching)
 {
   pcl::PointCloud<PointType> dst_raw_, src_raw_;
-  int num_approx = keyframes[i].pcd.size() * 2 * submap_range;
+  int num_approx = keyframes[src_idx].pcd.size() * 2 * submap_range;
   src_raw_.reserve(num_approx);
   dst_raw_.reserve(num_approx);
   if (enable_submap_matching)

--- a/third_party/fastlio_config_launch/kimera-multi.launch
+++ b/third_party/fastlio_config_launch/kimera-multi.launch
@@ -1,0 +1,21 @@
+<launch>
+<!-- Launch file for ouster OS2-64 LiDAR -->
+
+    <arg name="rviz" default="true" />
+
+    <rosparam command="load" file="$(find fast_lio)/../fastlio_config_launch/kimera-multi.yaml" />
+
+   <param name="feature_extract_enable" type="bool" value="0"/>-->
+   <param name="point_filter_num" type="int" value="4"/>-->
+   <param name="max_iteration" type="int" value="3" />-->
+   <param name="filter_size_surf" type="double" value="0.2" />-->
+   <param name="filter_size_map" type="double" value="0.2" />-->
+   <param name="cube_side_length" type="double" value="1000" />-->
+   <param name="runtime_pos_log_enable" type="bool" value="0" />-->
+   <node pkg="fast_lio" type="fastlio_mapping" name="laserMapping" output="screen" />
+
+    <group if="$(arg rviz)">
+    <node launch-prefix="nice" pkg="rviz" type="rviz" name="rviz" args="-d $(find fast_lio)/rviz_cfg/loam_livox.rviz" />
+    </group>
+
+</launch>

--- a/third_party/fastlio_config_launch/kimera-multi.yaml
+++ b/third_party/fastlio_config_launch/kimera-multi.yaml
@@ -1,0 +1,50 @@
+common:
+    lid_topic:  "/acl_jackal2/lidar_points"
+    imu_topic:  "/acl_jackal2/forward/imu"
+    # imu_topic:  "/acl_jackal2/imu/data"
+    time_sync_en: false         # ONLY turn on when external time synchronization is really not possible
+    time_offset_lidar_to_imu: 0.0 # Time offset between lidar and IMU calibrated by other algorithms, e.g. LI-Init (can be found in README).
+                                  # This param will take effect no matter what time_sync_en is. So if the time offset is not known exactly, please set as 0.0
+
+preprocess:
+    lidar_type: 2                # 1 for Livox serials LiDAR, 2 for Velodyne LiDAR, 3 for ouster LiDAR, 
+    scan_line: 16
+    scan_rate: 10                # only need to be set for velodyne, unit: Hz,
+    timestamp_unit: 2            # the unit of time/t field in the PointCloud2 rostopic: 0-second, 1-milisecond, 2-microsecond, 3-nanosecond.
+    blind: 0.3
+
+mapping:
+    acc_cov: 0.1
+    gyr_cov: 0.1
+    b_acc_cov: 0.01
+    b_gyr_cov: 0.005
+    fov_degree:    180
+    det_range:     100.0
+    extrinsic_est_en:  false      # true: enable the online estimation of IMU-LiDAR extrinsic,
+    # When using  /acl_jackal2/forward/imu
+    extrinsic_T: [ 0.07025405, -0.10158666, -0.04942693 ]
+    extrinsic_R: [-2.9046527369e-02, -9.9957706196e-01, -1.7154151723e-03,
+                   -6.9278006858e-02, 3.7251435690e-03, -9.9759064383e-01,
+                   9.9717458733e-01, -2.8857692625e-02, -6.9356874944e-02  ]
+
+    # When using  /acl_jackal2/imu/data (raw)
+    #extrinsic_T: [0.13, 0.0, 0.52]
+    #extrinsic_R: [1.0,  0.0,  0.0,
+    #              0.0,  1.0,  0.0,
+    #              0.0,  0.0,  1.0]
+    # When using  /acl_jackal2/imu/data (tuned by Parker)
+#    extrinsic_T: [ 0.06455307, -0.08247405, 0.47198666]
+#    extrinsic_R: [ 0.99717459, -0.02885769, -0.06935687,
+#                   0.02904653,  0.99957706,  0.00171542,
+#                   0.06927801, -0.00372514,  0.99759064]
+
+publish:
+    path_en:  true
+    scan_publish_en:  true       # false: close all the point cloud output
+    dense_publish_en: true       # false: low down the points number in a global-frame point clouds scan.
+    scan_bodyframe_pub_en: false  # true: output the point cloud scans in IMU-body-frame
+
+pcd_save:
+    pcd_save_en: false
+    interval: -1                 # how many LiDAR frames saved in each pcd file; 
+                                 # -1 : all frames will be saved in ONE pcd file, may lead to memory crash when having too much frames.

--- a/third_party/fastlio_config_launch/kitti.launch
+++ b/third_party/fastlio_config_launch/kitti.launch
@@ -3,7 +3,7 @@
 
     <arg name="rviz" default="true" />
 
-    <rosparam command="load" file="$(find fast_lio)/config/kitti.yaml" />
+    <rosparam command="load" file="$(find fast_lio)/../fastlio_config_launch/kitti.yaml" />
 
     <param name="feature_extract_enable" type="bool" value="0"/>
     <param name="point_filter_num" type="int" value="4"/>

--- a/third_party/fastlio_config_launch/mulran.launch
+++ b/third_party/fastlio_config_launch/mulran.launch
@@ -3,7 +3,7 @@
 
     <arg name="rviz" default="true" />
 
-    <rosparam command="load" file="$(find fast_lio)/config/mulran.yaml" />
+    <rosparam command="load" file="$(find fast_lio)/../fastlio_config_launch/mulran.yaml" />
 
     <param name="feature_extract_enable" type="bool" value="0"/>
     <param name="point_filter_num" type="int" value="3"/>

--- a/third_party/fastlio_config_launch/newer-college2020.launch
+++ b/third_party/fastlio_config_launch/newer-college2020.launch
@@ -1,0 +1,21 @@
+<launch>
+<!-- Launch file for ouster OS2-64 LiDAR -->
+
+    <arg name="rviz" default="true" />
+
+    <rosparam command="load" file="$(find fast_lio)/../fastlio_config_launch/newer-college2020.yaml" />
+
+    <param name="feature_extract_enable" type="bool" value="0"/>
+    <param name="point_filter_num" type="int" value="4"/>
+    <param name="max_iteration" type="int" value="3" />
+    <param name="filter_size_surf" type="double" value="0.5" />
+    <param name="filter_size_map" type="double" value="0.5" />
+    <param name="cube_side_length" type="double" value="1000" />
+    <param name="runtime_pos_log_enable" type="bool" value="0" />
+    <node pkg="fast_lio" type="fastlio_mapping" name="laserMapping" output="screen" /> 
+
+    <group if="$(arg rviz)">
+    <node launch-prefix="nice" pkg="rviz" type="rviz" name="rviz" args="-d $(find fast_lio)/rviz_cfg/loam_livox.rviz" />
+    </group>
+
+</launch>

--- a/third_party/fastlio_config_launch/newer-college2020.yaml
+++ b/third_party/fastlio_config_launch/newer-college2020.yaml
@@ -1,0 +1,36 @@
+common:
+    lid_topic:  "/os1_cloud_node/points"
+    imu_topic:  "/os1_cloud_node/imu"
+    time_sync_en: false           # ONLY turn on when external time synchronization is really not possible
+    time_offset_lidar_to_imu: 0.0 # Time offset between lidar and IMU calibrated by other algorithms, e.g. LI-Init (can be found in README).
+                                  # This param will take effect no matter what time_sync_en is. So if the time offset is not known exactly, please set as 0.0
+    
+preprocess:
+    lidar_type: 3                # 1 for Livox serials LiDAR, 2 for Velodyne LiDAR, 3 for ouster LiDAR, 
+    scan_line: 64
+    timestamp_unit: 3                 # 0-second, 1-milisecond, 2-microsecond, 3-nanosecond.
+    blind: 1
+
+mapping:
+    acc_cov: 0.1
+    gyr_cov: 0.1
+    b_acc_cov: 0.0001
+    b_gyr_cov: 0.0001
+    fov_degree:    180
+    det_range:     150.0
+    extrinsic_est_en:  false      # true: enable the online estimation of IMU-LiDAR extrinsic
+    extrinsic_T: [ 0.0, 0.0, 0.036 ]
+    extrinsic_R: [-1, 0, 0,
+                  0, -1, 0,
+                  0, 0, 1]
+
+publish:
+    path_en:  false
+    scan_publish_en:  true       # false: close all the point cloud output
+    dense_publish_en: true       # false: low down the points number in a global-frame point clouds scan.
+    scan_bodyframe_pub_en: true  # true: output the point cloud scans in IMU-body-frame
+
+pcd_save:
+    pcd_save_en: true
+    interval: -1                 # how many LiDAR frames saved in each pcd file; 
+                                 # -1 : all frames will be saved in ONE pcd file, may lead to memory crash when having too much frames.

--- a/third_party/fastlio_config_launch/vbr-colosseo.launch
+++ b/third_party/fastlio_config_launch/vbr-colosseo.launch
@@ -3,13 +3,13 @@
 
     <arg name="rviz" default="true" />
 
-    <rosparam command="load" file="$(find fast_lio)/../fastlio_config_launch/kimera-multi.yaml" />
+    <rosparam command="load" file="$(find fast_lio)/../fastlio_config_launch/vbr-colosseo.yaml" />
 
    <param name="feature_extract_enable" type="bool" value="0"/>-->
    <param name="point_filter_num" type="int" value="4"/>-->
    <param name="max_iteration" type="int" value="3" />-->
-   <param name="filter_size_surf" type="double" value="0.2" />-->
-   <param name="filter_size_map" type="double" value="0.2" />-->
+   <param name="filter_size_surf" type="double" value="0.5" />-->
+   <param name="filter_size_map" type="double" value="0.5" />-->
    <param name="cube_side_length" type="double" value="1000" />-->
    <param name="runtime_pos_log_enable" type="bool" value="0" />-->
    <node pkg="fast_lio" type="fastlio_mapping" name="laserMapping" output="screen" />

--- a/third_party/fastlio_config_launch/vbr-colosseo.launch
+++ b/third_party/fastlio_config_launch/vbr-colosseo.launch
@@ -1,0 +1,21 @@
+<launch>
+<!-- Launch file for ouster OS2-64 LiDAR -->
+
+    <arg name="rviz" default="true" />
+
+    <rosparam command="load" file="$(find fast_lio)/../fastlio_config_launch/kimera-multi.yaml" />
+
+   <param name="feature_extract_enable" type="bool" value="0"/>-->
+   <param name="point_filter_num" type="int" value="4"/>-->
+   <param name="max_iteration" type="int" value="3" />-->
+   <param name="filter_size_surf" type="double" value="0.2" />-->
+   <param name="filter_size_map" type="double" value="0.2" />-->
+   <param name="cube_side_length" type="double" value="1000" />-->
+   <param name="runtime_pos_log_enable" type="bool" value="0" />-->
+   <node pkg="fast_lio" type="fastlio_mapping" name="laserMapping" output="screen" />
+
+    <group if="$(arg rviz)">
+    <node launch-prefix="nice" pkg="rviz" type="rviz" name="rviz" args="-d $(find fast_lio)/rviz_cfg/loam_livox.rviz" />
+    </group>
+
+</launch>

--- a/third_party/fastlio_config_launch/vbr-colosseo.yaml
+++ b/third_party/fastlio_config_launch/vbr-colosseo.yaml
@@ -21,10 +21,10 @@ mapping:
     fov_degree:    180
     det_range:     100.0
     extrinsic_est_en:  false      # true: enable the online estimation of IMU-LiDAR extrinsic,
-    extrinsic_T: [ -0.045630250613467524, -0.00784852988506693, -0.6084150115067585]
-    extrinsic_R: [0.9994652045891429, 0.03194161690749185, -0.00698788259543323,
-                 -0.03200263570684775, 0.9994490166874298, -0.008798074077210848,
-                  0.006703021917434096, 0.009017052443448963, 0.9999368527795895 ]
+    extrinsic_T: [0.04943289, 0.01478779, 0.60798871]
+    extrinsic_R: [ 0.99946541, -0.03200262, 0.00670301,
+                   0.03194165,  0.99944911, 0.009017,
+                   -0.0069879, -0.00879813, 0.99993691 ]
 publish:
     path_en:  true
     scan_publish_en:  true       # false: close all the point cloud output

--- a/third_party/fastlio_config_launch/vbr-colosseo.yaml
+++ b/third_party/fastlio_config_launch/vbr-colosseo.yaml
@@ -1,0 +1,37 @@
+common:
+    lid_topic:  "/ouster/points"
+    imu_topic:  "/imu/data"
+    # imu_topic:  "/acl_jackal2/imu/data"
+    time_sync_en: false         # ONLY turn on when external time synchronization is really not possible
+    time_offset_lidar_to_imu: 0.0 # Time offset between lidar and IMU calibrated by other algorithms, e.g. LI-Init (can be found in README).
+                                  # This param will take effect no matter what time_sync_en is. So if the time offset is not known exactly, please set as 0.0
+
+preprocess:
+    lidar_type: 3                # 1 for Livox serials LiDAR, 2 for Velodyne LiDAR, 3 for ouster LiDAR,
+    scan_line: 64
+    scan_rate: 10                # only need to be set for velodyne, unit: Hz,
+    timestamp_unit: 3            # the unit of time/t field in the PointCloud2 rostopic: 0-second, 1-milisecond, 2-microsecond, 3-nanosecond.
+    blind: 0.3
+
+mapping:
+    acc_cov: 0.01
+    gyr_cov: 0.001
+    b_acc_cov: 0.001
+    b_gyr_cov: 0.0005
+    fov_degree:    180
+    det_range:     100.0
+    extrinsic_est_en:  false      # true: enable the online estimation of IMU-LiDAR extrinsic,
+    extrinsic_T: [ -0.045630250613467524, -0.00784852988506693, -0.6084150115067585]
+    extrinsic_R: [0.9994652045891429, 0.03194161690749185, -0.00698788259543323,
+                 -0.03200263570684775, 0.9994490166874298, -0.008798074077210848,
+                  0.006703021917434096, 0.009017052443448963, 0.9999368527795895 ]
+publish:
+    path_en:  true
+    scan_publish_en:  true       # false: close all the point cloud output
+    dense_publish_en: true       # false: low down the points number in a global-frame point clouds scan.
+    scan_bodyframe_pub_en: false  # true: output the point cloud scans in IMU-body-frame
+
+pcd_save:
+    pcd_save_en: false
+    interval: -1                 # how many LiDAR frames saved in each pcd file; 
+                                 # -1 : all frames will be saved in ONE pcd file, may lead to memory crash when having too much frames.


### PR DESCRIPTION
First of all, sorry for this dirty PR (at some point, I forgot to do PR before I proceeded to refactor loop closure mode)

---

1. Note that the original Quatro/Quatro++ paper deliberately used imprecise FPFH parameters to check the robustness of outlier-robust registration. Emprically, 2-3 and 5 times are better, respectively (67ee021)
2. Currently, I added some codes to save pcd and pose files in TUM and KITTI format (1b38a2e1 and 9bfbbb3b)
3. And force save mode is implemented (6bc82dea), which works if we publish the topic as follows:

```
rostopic pub /save_dir std_msgs/String "data: /media/shapelim/UX960NVMe1/kimera-multi/fast_lio_sam_qn/mit_red"\n
rostopic pub /save_dir std_msgs/String "data: /media/shapelim/UX960NVMe1/kimera-multi/fast_lio_sam_qn/mit_purple"\n
rostopic pub /save_dir std_msgs/String "data: /media/shapelim/UX960NVMe1/kimera-multi/fast_lio_sam_qn/mit_green"\n
rostopic pub /save_dir std_msgs/String "data: /media/shapelim/UX960NVMe1/vbr-colosseo"
```

4. Support other datasets (cc4f7c48, 811139a8, and cf24baa6)
5. Loop closing detection parts are refactored because there are too many repetitive copy & paste codes (43a79bb1, 6efb9503, af1f136c, and 07c7b651). 
